### PR TITLE
Fix: Prevent animation on invalid moves and handle undefined coordinates

### DIFF
--- a/src/script/actors/actor.ts
+++ b/src/script/actors/actor.ts
@@ -410,6 +410,9 @@ export default class Actor extends WorldObject {
 
         if (game.world.canWalk(destination.x, destination.y)) {
             const walkable = game.world.getHeight(destination.x, destination.y);
+
+            
+
             if (walkable >= 0 && Math.abs(this.position.z - walkable) <= 0.5) {
                 return { x: destination.x, y: destination.y, z: walkable };
             }
@@ -544,6 +547,8 @@ export default class Actor extends WorldObject {
                 }
                 this.unWalkable = false;
                 
+              
+
                 // Move to destination (absolute positioning)
                 this.move(this.destination.x, this.destination.y, this.destination.z, true);
                 this.destination = false;
@@ -562,6 +567,12 @@ export default class Actor extends WorldObject {
     }
 
     move(x: number, y: number, z?: number, absolute?: boolean): void {
+
+        if (x === undefined || y === undefined) {
+        console.error('Actor.move: Received undefined coordinates, move cancelled.', { actor: this.username });
+        return;
+    }
+
         // Validate input parameters
         if (isNaN(x) || isNaN(y) || (typeof z !== 'undefined' && isNaN(z))) {
             console.error('Actor.move: Invalid coordinates provided', {

--- a/src/script/actors/behaviors/goto.ts
+++ b/src/script/actors/behaviors/goto.ts
@@ -117,10 +117,21 @@ export default class GoTo {
                     }
                 }
                 
-                //this.attempt = util.randomIntRange(1,4); // Reset adjacent attempts
-                this.actor.destination = finalDestination;
-                this.actor.startMove();
-                this.actor.once('movecomplete', this.boundStartGoTo);
+                // Try to move to the first step suggested by the pathfinder
+                const pathDeltaY = finalDestination.y - this.actor.position.y;
+                const pathDeltaX = finalDestination.x - this.actor.position.x;
+                const pathMoveAttempt = this.actor.tryMove(pathDeltaX, pathDeltaY);
+
+                // THIS IS THE FIX: Only start the move if the path step is valid
+                if (pathMoveAttempt) {
+                    this.actor.destination = pathMoveAttempt;
+                     this.actor.startMove();
+                     this.actor.once('movecomplete', this.boundStartGoTo);
+                } else {
+                // The first step of the path is blocked, so let's try finding a new path
+                this.attempt++;
+                 this.startGoTo();
+        }
             } else { // If no path, try next closest tile
                 this.attempt++;
                 if (this.attempt > 8) { // Prevent infinite recursion


### PR DESCRIPTION
This pull request resolves issue #27 by fixing two related bugs.

**Bugs Addressed:**

* The hopping animation would incorrectly play for invalid moves, such as when the height difference was too large.
* A separate issue was causing errors due to `undefined` coordinates being passed to the actor's `move` function.

**Solution:**

* The logic in `goto.ts` has been updated to validate a move suggested by the pathfinder **before** triggering the movement animation. This ensures the animation only plays for valid moves.
* A guard clause has been added to the `move` function in `actor.ts` to safely handle any `undefined` coordinates, preventing potential errors.

Closes #27