### PR TITLE
Fix: When switching server actors can be spawned on invalid position!

### DIFF
--- a/src/gameLogger.ts
+++ b/src/gameLogger.ts
@@ -130,6 +130,25 @@ class GameLogger {
     }, `World generated: ${data.totalTiles} tiles, ${data.spawnablePositions} spawn positions`);
   }
 
+  /**
+   * World spawn position analysis completed
+   */
+  worldSpawnAnalysis(data: {
+    totalPositions: number;
+    validSpawnPositions: number;
+    invalidSpawnPositions: number;
+    validPositions: string[];
+    invalidPositions: string[];
+  }): void {
+    if (!this.enabled) return;
+    this.baseLogger.info({
+      category: 'world',
+      event: 'spawn_analysis',
+      timestamp: Date.now(),
+      ...data
+    }, `Spawn analysis: ${data.validSpawnPositions} valid, ${data.invalidSpawnPositions} invalid positions`);
+  }
+
   // ===========================================
   // ACTOR SYSTEM EVENTS
   // ===========================================

--- a/src/gameLogger.ts
+++ b/src/gameLogger.ts
@@ -105,6 +105,32 @@ class GameLogger {
   }
 
   // ===========================================
+  // WORLD GENERATION EVENTS
+  // ===========================================
+
+  /**
+   * World generation completed
+   */
+  worldGenerated(data: {
+    totalTiles: number;
+    spawnablePositions: number;
+    worldSize: number;
+    worldRadius: number;
+    mapBounds: { xl: number; yl: number; xh: number; yh: number };
+    mainIslandSize?: number;
+    totalIslands?: number;
+    spawnPositions?: string[];
+  }): void {
+    if (!this.enabled) return;
+    this.baseLogger.info({
+      category: 'world',
+      event: 'generated',
+      timestamp: Date.now(),
+      ...data
+    }, `World generated: ${data.totalTiles} tiles, ${data.spawnablePositions} spawn positions`);
+  }
+
+  // ===========================================
   // ACTOR SYSTEM EVENTS
   // ===========================================
 
@@ -523,5 +549,6 @@ export { logger as baseLogger };
 
 // Export types for TypeScript support
     export type {
-        GameLogger
-    };
+    GameLogger
+  };
+

--- a/src/main.ts
+++ b/src/main.ts
@@ -696,4 +696,6 @@ export function startApp(): void {
 // Auto-start the app if this module is being run in the browser (not being imported for testing)
 if (typeof window !== 'undefined' && typeof document !== 'undefined') {
     startApp();
+    // Make joinServer available globally for E2E testing
+    (window as any).joinServer = joinServer;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -379,7 +379,7 @@ export function initWebsocket(): void {
         //const TestSocket = require('./script/engine/tester.js'),
         //ws = new TestSocket(50, 3000);
         
-        ws.addEventListener('message', function(event) {
+        ws.addEventListener('message', async function(event) {
             const data = JSON.parse(event.data);
             gameLogger.websocketMessageReceived(data);
             
@@ -497,6 +497,10 @@ export function initWebsocket(): void {
                 
                 // Initialize the game components now that they're properly converted to TS
                 world = new World(game as any, Math.round(3.3 * Math.sqrt(Object.keys(userList).length)));
+                
+                // Wait for world generation to complete before spawning actors
+                await world.initializationPromise;
+                
                 decorator = new Decorator(game as any, world as any);
                 game.decorator = decorator;
                 users = new Users(game as any, world as any);

--- a/src/script/actors/actor.ts
+++ b/src/script/actors/actor.ts
@@ -128,6 +128,17 @@ export default class Actor extends WorldObject {
     addToGame(game: any): void {
         super.addToGame(game);
         
+        // Log actor spawning
+        gameLogger.actorSpawned({
+            uid: this.uid,
+            username: this.username,
+            x: this.position.x,
+            y: this.position.y,
+            z: this.position.z,
+            roleColor: this.roleColor,
+            presence: this.presence
+        });
+        
         // Add role color sheet if needed
         if (this.roleColor) {
             game.renderer.addColorSheet({

--- a/src/script/environment/world.ts
+++ b/src/script/environment/world.ts
@@ -72,6 +72,7 @@ export default class World extends EventEmitter {
     islands: Slab[][] = [];
     mainIsland: number = 0;
     tileMap: Record<string, Tile> = {};
+    initializationPromise: Promise<void>;
 
     constructor(game: Game, worldSize: number) {
         super();
@@ -80,7 +81,7 @@ export default class World extends EventEmitter {
         this.worldSize = Math.max(24, Math.floor(worldSize / 2) * 2); // Must be an even number >= 24
         this.worldRadius = Math.floor(this.worldSize / 2);
         
-        this.init();
+        this.initializationPromise = this.init();
     }
 
     private async init(): Promise<void> {        

--- a/src/script/environment/world.ts
+++ b/src/script/environment/world.ts
@@ -1,10 +1,10 @@
 'use strict';
 
 import { EventEmitter } from 'events';
-import { util } from '../common/util.js';
-import { geometry } from '../common/geometry.js';
-import BetterCanvas from '../common/bettercanvas.js';
 import { gameLogger } from '../../gameLogger.js';
+import BetterCanvas from '../common/bettercanvas.js';
+import { geometry } from '../common/geometry.js';
+import { util } from '../common/util.js';
 
 // We'll need to convert these dependencies or use dynamic imports
 interface Slab {
@@ -161,6 +161,18 @@ export default class World extends EventEmitter {
         if (beaconIndex > -1) {
             unoccupiedGrids.splice(beaconIndex, 1); // 0,0 is taken by beacon
         }
+        
+        // Log world generation completion with spawn positions
+        gameLogger.worldGenerated({ 
+            totalTiles: Object.keys(this.map).length,
+            spawnablePositions: unoccupiedGrids.length,
+            worldSize: this.worldSize,
+            worldRadius: this.worldRadius,
+            mapBounds: this.mapBounds,
+            mainIslandSize: this.islands[this.mainIsland]?.length || 0,
+            totalIslands: this.islands.length,
+            spawnPositions: unoccupiedGrids.slice(0, 10) // Log first 10 spawn positions as sample
+        });
         
         gameLogger.info('World: Created world', { 
             tileCount: Object.keys(this.map).length 

--- a/tests/actor-spawn-validation.e2e.ts
+++ b/tests/actor-spawn-validation.e2e.ts
@@ -257,8 +257,8 @@ test.describe('@critical Actor Spawn Validation', () => {
           console.log(`📍 Valid positions sample: ${validSpawnPositions.slice(0, 10).join(', ')}`);
           console.log(`🚫 Invalid positions: ${invalidSpawnPositions.join(', ')}`);
           
-          // This is the bug we expect to find - let the test fail to demonstrate it
-          expect(isValidPosition).toBe(true); // This may fail and that's expected
+          // The test should fail when actors spawn at invalid positions
+          expect(isValidPosition).toBe(true);
         } else {
           console.log(`✓ Actor ${username} spawned at VALID position (${x}, ${y}, ${z})`);
         }
@@ -478,7 +478,9 @@ test.describe('@critical Actor Spawn Validation', () => {
             if (!spawnedInValidPosition) {
               console.log(`❌ Actor ${username} spawned at INVALID position (${x}, ${y}, ${z}) - not in new world's valid spawn list`);
               console.log(`📍 Sample valid positions: ${newValidSpawnPositions.slice(0, 5).join(', ')}`);
-              // This may reveal the spawn bug the user mentioned
+              
+              // The test should fail when actors spawn at invalid positions
+              expect(spawnedInValidPosition).toBe(true);
             }
           }
           
@@ -487,10 +489,12 @@ test.describe('@critical Actor Spawn Validation', () => {
             validActors++;
           } else {
             if (!isValidX || !isValidY || !isValidZ) {
-              console.log(`⚠️  Actor ${username} has invalid coordinates: (${x}, ${y}, ${z}) - non-integer values detected`);
+              console.log(`❌ Actor ${username} has invalid coordinates: (${x}, ${y}, ${z}) - non-integer values detected`);
+              expect(isValidX && isValidY && isValidZ).toBe(true);
             }
             if (!spawnedInValidPosition) {
-              console.log(`⚠️  Actor ${username} spawned at invalid world position: (${x}, ${y}, ${z})`);
+              console.log(`❌ Actor ${username} spawned at invalid world position: (${x}, ${y}, ${z})`);
+              expect(spawnedInValidPosition).toBe(true);
             }
             invalidActors++;
           }
@@ -508,11 +512,8 @@ test.describe('@critical Actor Spawn Validation', () => {
       
       console.log(`📊 Coordinate validation summary: ${validActors} valid, ${invalidActors} invalid actors`);
       
-      // Report the results but don't fail the test if invalid coordinates are found
-      // (since user mentioned this is a known bug)
-      if (invalidActors > 0) {
-        console.log(`⚠️  Detected ${invalidActors} actors with invalid coordinates - this may be the known spawn bug`);
-      }
+      // All actors should have valid coordinates - the test should fail if any don't
+      expect(invalidActors).toBe(0);
       
       // Ensure at least some actors were processed
       expect(validActors + invalidActors).toBeGreaterThan(0);

--- a/tests/actor-spawn-validation.e2e.ts
+++ b/tests/actor-spawn-validation.e2e.ts
@@ -1,0 +1,219 @@
+/**
+ * @file E2E tests for actor spawn coordinate validation
+ * @description Tests that validate actor spawn coordinate systems and world generation
+ * 
+ * This test suite follows the Canvas Testing Guide approach using log-based testing
+ * to verify that:
+ * 1. World generation creates valid spawn positions
+ * 2. Any actors that do spawn have valid coordinates within world bounds  
+ * 3. No coordinate calculation errors occur (NaN, Infinity, etc.)
+ * 4. Coordinate system follows game requirements (integer grid positions)
+ * 
+ * The tests are designed to be robust whether actors spawn automatically or not,
+ * focusing on validating the underlying coordinate system integrity.
+ */
+
+import { expect, test } from '@playwright/test';
+import { CanvasGameTestUtils, GameAssertions, GameLogEvent } from './utils/canvasTestUtils.js';
+
+test.describe('@critical Actor Spawn Validation', () => {
+  let gameUtils: CanvasGameTestUtils;
+
+  test.beforeEach(async ({ page }) => {
+    gameUtils = new CanvasGameTestUtils(page);
+    await gameUtils.startLogCapture();
+    
+    // Navigate to the game
+    await page.goto('/?e2e-test=true');
+    
+    // Verify canvas is visible before testing
+    await GameAssertions.assertCanvasVisible(page);
+  });
+
+  test('@critical should have valid world generation for actor spawning', async ({ page }) => {
+    // Wait for game initialization and world generation
+    await gameUtils.waitForGameEvent('game', 'initialized', 15000);
+    
+    // Wait for world generation to complete
+    const worldGenEvent = await gameUtils.waitForGameEvent('world', 'generated', 15000);
+    
+    // Verify world generation provides valid spawn data
+    expect(worldGenEvent).toBeTruthy();
+    expect(worldGenEvent.data).toBeTruthy();
+    
+    const { spawnablePositions, mapBounds, worldRadius, totalTiles } = worldGenEvent.data;
+    
+    // Verify world has valid spawn positions
+    expect(spawnablePositions).toBeGreaterThan(0);
+    expect(totalTiles).toBeGreaterThan(0);
+    expect(mapBounds).toBeTruthy();
+    expect(worldRadius).toBeGreaterThan(0);
+    
+    // Verify map bounds are reasonable
+    expect(mapBounds.xl).toBeLessThanOrEqual(mapBounds.xh);
+    expect(mapBounds.yl).toBeLessThanOrEqual(mapBounds.yh);
+    expect(Math.abs(mapBounds.xl)).toBeLessThanOrEqual(worldRadius);
+    expect(Math.abs(mapBounds.xh)).toBeLessThanOrEqual(worldRadius);
+    expect(Math.abs(mapBounds.yl)).toBeLessThanOrEqual(worldRadius);
+    expect(Math.abs(mapBounds.yh)).toBeLessThanOrEqual(worldRadius);
+    
+    // Verify sample spawn positions are valid coordinates
+    if (worldGenEvent.data.spawnPositions) {
+      const samplePositions = worldGenEvent.data.spawnPositions;
+      expect(Array.isArray(samplePositions)).toBe(true);
+      
+      for (const pos of samplePositions) {
+        expect(typeof pos).toBe('string');
+        const [x, y] = pos.split(':').map(Number);
+        expect(Number.isInteger(x)).toBe(true);
+        expect(Number.isInteger(y)).toBe(true);
+        expect(Number.isFinite(x)).toBe(true);
+        expect(Number.isFinite(y)).toBe(true);
+        
+        // Should not be the beacon position
+        expect(!(x === 0 && y === 0)).toBe(true);
+      }
+    }
+    
+    console.log(`✓ World generated with ${spawnablePositions} valid spawn positions within bounds`);
+  });
+
+  test('@critical should validate coordinates when actors do spawn', async ({ page }) => {
+    // Wait for game and world initialization
+    await gameUtils.waitForGameEvent('game', 'initialized', 15000);
+    await gameUtils.waitForGameEvent('world', 'generated', 10000);
+    
+    // Get world bounds for validation
+    const worldGenLogs = gameUtils.getLogsByCategory('world')
+      .filter(log => log.event === 'generated');
+    const worldInfo = worldGenLogs[0];
+    const { mapBounds } = worldInfo.data;
+    
+    // Check logs from initialization (don't clear - need server-join message!)
+    console.log('🔍 Checking logs from initialization...');
+    
+    // Get all captured logs for analysis
+    const allLogs = gameUtils.getAllLogs();
+    const logsByCategory = allLogs.reduce((acc, log) => {
+      acc[log.category] = (acc[log.category] || 0) + 1;
+      return acc;
+    }, {} as Record<string, number>);
+    
+    // Check for actor spawn events
+    const actorLogs = gameUtils.getLogsByCategory('actor');
+    console.log(`📊 Actor logs found: ${actorLogs.length}`);
+    
+    // Get any actor spawn events that occurred
+    const spawnLogs = gameUtils.getLogsByCategory('actor')
+      .filter(log => log.event === 'spawned');
+    
+    if (spawnLogs.length === 0) {
+      console.log('ℹ No actors spawned automatically - test validates coordinate format requirements');
+      
+      // Test the coordinate validation logic by checking that the world bounds are reasonable
+      expect(mapBounds.xl).toBeLessThanOrEqual(mapBounds.xh);
+      expect(mapBounds.yl).toBeLessThanOrEqual(mapBounds.yh);
+      expect(Number.isInteger(mapBounds.xl)).toBe(true);
+      expect(Number.isInteger(mapBounds.xh)).toBe(true);
+      expect(Number.isInteger(mapBounds.yl)).toBe(true);
+      expect(Number.isInteger(mapBounds.yh)).toBe(true);
+      
+      console.log('✓ World bounds are valid integers for coordinate system');
+      return;
+    }
+    
+    // If actors did spawn, validate their coordinates
+    console.log(`Found ${spawnLogs.length} actor spawn(s) to validate`);
+    
+    for (const spawnLog of spawnLogs) {
+      const { uid, username, x, y, z } = spawnLog.data;
+      
+      // Basic coordinate validation
+      expect(typeof x).toBe('number');
+      expect(typeof y).toBe('number');
+      expect(typeof z).toBe('number');
+      
+      expect(Number.isFinite(x)).toBe(true);
+      expect(Number.isFinite(y)).toBe(true);
+      expect(Number.isFinite(z)).toBe(true);
+      
+      // Coordinates should not be NaN
+      expect(Number.isNaN(x)).toBe(false);
+      expect(Number.isNaN(y)).toBe(false);
+      expect(Number.isNaN(z)).toBe(false);
+      
+      // X and Y should be integers (grid-based world)
+      expect(Number.isInteger(x)).toBe(true);
+      expect(Number.isInteger(y)).toBe(true);
+      
+      // Coordinates should be within reasonable world bounds
+      expect(x).toBeGreaterThanOrEqual(mapBounds.xl - 1);
+      expect(x).toBeLessThanOrEqual(mapBounds.xh + 1);
+      expect(y).toBeGreaterThanOrEqual(mapBounds.yl - 1);
+      expect(y).toBeLessThanOrEqual(mapBounds.yh + 1);
+      
+      // Z coordinate should be reasonable
+      expect(z).toBeGreaterThanOrEqual(-10);
+      expect(z).toBeLessThanOrEqual(10);
+      
+      // Should not spawn at beacon position
+      expect(!(x === 0 && y === 0)).toBe(true);
+      
+      console.log(`✓ Actor ${username} (${uid}) has valid coordinates: (${x}, ${y}, ${z})`);
+    }
+  });
+
+  test('@critical should detect coordinate errors if they occur', async ({ page }) => {
+    // Wait for game and world initialization
+    await gameUtils.waitForGameEvent('game', 'initialized', 15000);
+    await gameUtils.waitForGameEvent('world', 'generated', 10000);
+    
+    // Monitor logs for coordinate-related errors
+    gameUtils.clearLogs();
+    await page.waitForTimeout(15000); // Wait longer for potential issues
+    
+    // Check for any coordinate-related error logs
+    const allRecentLogs = gameUtils.getAllLogs();
+    const coordinateErrors = allRecentLogs
+      .filter((log: GameLogEvent) => 
+        log.level === 'error' && 
+        (log.data?.hasNaN === true || 
+         (typeof log.data === 'object' && 
+          log.data !== null && 
+          Object.values(log.data).some((value: any) => 
+            typeof value === 'number' && (Number.isNaN(value) || !Number.isFinite(value))
+          )))
+      );
+    
+    // Should have no coordinate-related errors
+    expect(coordinateErrors.length).toBe(0);
+    
+    // Also check for any actor spawn events and validate them
+    const spawnLogs = gameUtils.getLogsByCategory('actor')
+      .filter(log => log.event === 'spawned');
+    
+    // If any actors spawned, verify they have clean coordinate data
+    for (const spawnLog of spawnLogs) {
+      const { x, y, z } = spawnLog.data;
+      
+      // Should not be edge case values
+      expect(x).not.toBe(Infinity);
+      expect(x).not.toBe(-Infinity);
+      expect(y).not.toBe(Infinity);
+      expect(y).not.toBe(-Infinity);
+      expect(z).not.toBe(Infinity);
+      expect(z).not.toBe(-Infinity);
+      
+      // Should not be extremely large values that might indicate calculation errors
+      expect(Math.abs(x)).toBeLessThan(1000);
+      expect(Math.abs(y)).toBeLessThan(1000);
+      expect(Math.abs(z)).toBeLessThan(100);
+    }
+    
+    if (spawnLogs.length > 0) {
+      console.log(`✓ Validated ${spawnLogs.length} actors with clean coordinate data, no errors detected`);
+    } else {
+      console.log('✓ No coordinate errors detected during monitoring period');
+    }
+  });
+});

--- a/tests/utils/canvasTestUtils.ts
+++ b/tests/utils/canvasTestUtils.ts
@@ -181,6 +181,13 @@ export class CanvasGameTestUtils {
   }
 
   /**
+   * Get all captured logs
+   */
+  getAllLogs(): GameLogEvent[] {
+    return [...this.logs];
+  }
+
+  /**
    * Get recent logs (last N seconds)
    */
   getRecentLogs(seconds: number = 5): GameLogEvent[] {


### PR DESCRIPTION
Added tests that verifies if the actor has spawned on a valid position.
When loading the game for the first time the spawn logic works fine.
The spawn logic is not working fine when switching server.