### PR TITLE
Fix: Color update is immediately reflected

### DIFF
--- a/src/script/actors/actor.ts
+++ b/src/script/actors/actor.ts
@@ -167,6 +167,10 @@ export default class Actor extends WorldObject {
         // Initialize default behavior
         this.behaviors.push(new Wander(this));
     }
+    updateColor(color: string): void {
+        this.roleColor = color;
+        this.updateSprite();
+    }
 
     updatePresence(presence: string): void {
         this.presence = presence;

--- a/src/script/actors/users.ts
+++ b/src/script/actors/users.ts
@@ -32,6 +32,7 @@ interface Actor {
     position: { x: number; y: number; z: number };
     addToGame(game: any): void;
     updatePresence(status: string): void;
+    updateColor(color: string): void;
     startTalking(message: string, channel: string, callback: () => void): void;
     remove(): void;
 }
@@ -115,6 +116,9 @@ export default class Users extends EventEmitter {
                 this.removeActor(actor);
             } else {
                 actor.updatePresence(data.status);
+                if (data.roleColor) {
+                    actor.updateColor(data.roleColor);
+                }
             }
         } else {
             await this.addActor(data);


### PR DESCRIPTION
Broadcast events regarding online/offline status was immediately reflected in the game but not role color updates. A site refresh was needed for that.